### PR TITLE
Wrapper objects should not be used for primitive types

### DIFF
--- a/components/AddTodo.vue
+++ b/components/AddTodo.vue
@@ -25,11 +25,11 @@ import 'vue2-animate/dist/vue2-animate.min.css'
 export default Vue.extend({
   name: 'AddTodo',
   data() {
-    const todoText: String = ''
+    const todoText: string = ''
     return { todoText }
   },
   computed: {
-    disableSubmit(): Boolean {
+    disableSubmit(): boolean {
       return this.todoText === ''
     },
   },

--- a/components/ListTodos.vue
+++ b/components/ListTodos.vue
@@ -11,7 +11,6 @@
 
         <div class="space-x-2">
           <button class="btn-error" @click="deleteTodo(index)">Delete</button>
-
           <button
             v-if="!todo.done"
             class="btn-standard"


### PR DESCRIPTION
The use of wrapper objects for primitive types is gratuitous, confusing and dangerous. If you use a wrapper object constructor for type conversion, just remove the new keyword, and you'll get a primitive value automatically. If you use a wrapper object as a way to add properties to a primitive, you should re-think the design. Such uses are considered bad practice, and should be refactored.